### PR TITLE
Better stack traces for timeout errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@await/event",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Asynchronous bridge for event emitters.",
   "main": "event.js",
   "repository": {


### PR DESCRIPTION
The primary purpose of this PR is to provide better stack traces for timeout errors. Prior to this change timeout errors have a stack trace impossible to follow, since the setTimeout loses the original stack.

I also added a couple more errors which will throw if a user uses the API incorrectly; the result of which would be awaiting the promise until the heat death of the universe.